### PR TITLE
Allow passing of axios_config

### DIFF
--- a/lib/core/main.js
+++ b/lib/core/main.js
@@ -41,7 +41,7 @@ async function search(query, options = {}) {
     Constants.URLS.GOOGLE + 'search?q=' + query + '&ie=UTF-8&aomd=1' + (options.safe && '&safe=active' || '') +
     '&start=' + options.page);
 
-  const response = await Axios.get(url, { params: options.additional_params, headers: Utils.getHeaders({ mobile: true }) }).catch((err) => err);
+  const response = await Axios.get(url, { params: options.additional_params, headers: Utils.getHeaders({ mobile: true }), ...options.axios_config}).catch((err) => err);
   if (response instanceof Error) throw new Utils.SearchError('Could not execute search', { status_code: response?.status || 0, message: response?.message });
   
   const results = {
@@ -163,7 +163,8 @@ async function image(query, options = {}) {
     headers: {
       'content-type': 'application/x-www-form-urlencoded;charset=UTF-8',
       ...Utils.getHeaders({ mobile: false })
-    }
+    },
+    ...options.axios_config
   }).catch((err) => err);
   
   if (response instanceof Error)
@@ -222,7 +223,7 @@ async function image(query, options = {}) {
 async function getTopNews(language = 'en', region = 'US') {
   const url = Constants.URLS.GOOGLE_NEWS + `topstories?tab=in&hl=${language.toLocaleLowerCase()}-${region.toLocaleUpperCase()}&gl=${region.toLocaleUpperCase()}&ceid=${region.toLocaleUpperCase()}:${language.toLocaleLowerCase()}`;
 
-  const response = await Axios.get(url, { headers: Utils.getHeaders({ mobile: true }) }).catch((err) => err);
+  const response = await Axios.get(url, { headers: Utils.getHeaders({ mobile: true }), ...options.axios_config }).catch((err) => err);
   if (response instanceof Error) throw new Error('Could not retrieve top news: ' + response.message);
 
   const $ = Cheerio.load(response.data);


### PR DESCRIPTION
## Description

This PR is fairly simple. It just gives you the ability to pass extra `axios_config` in the `options` parameter. The 

It Fixes https://github.com/LuanRT/google-this/issues/21 by allowing you to pass proxy servers.

```javascript
import SocksProxyAgent from 'socks-proxy-agent';

const httpsAgent = new SocksProxyAgent.SocksProxyAgent(...);
const options = {
  page: 0,
  safe: false,
  additional_params: {
    hl: 'en'
  },
  axios_config: {
    timeout: 15000,
    proxy: false,
    httpsAgent: httpsAgent
  }
}

const response = await google.search('how do you scrape google results?', options);
```

It should support standard HTTPS proxies, too. I just generally use Socks5.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
