### PR TITLE
fix: update image origin information index

### DIFF
--- a/lib/core/main.js
+++ b/lib/core/main.js
@@ -232,7 +232,7 @@ async function image(query, options = {}) {
 
     const image = item[1]?.[3];
     const preview = item[1]?.[2];
-    const origin = item[1]?.[9];
+    const origin = item[1]?.[22];
 
     if (image && preview && origin)
       return {


### PR DESCRIPTION
# Image Search Fix

## Description

The image search feature wasn't working and was always returning an empty array.

## Fixes

It seems that the index that refers to the origin changed from 9 to 22, so I just changed that.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas (it wasn't necessary)
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (it wasn't necessary)
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
