### PR TITLE
Properly encode query string

### DIFF
--- a/lib/core/main.js
+++ b/lib/core/main.js
@@ -48,16 +48,15 @@ async function search(query, options = {}) {
   if (typeof query === 'object' && ris) {
     response = await uploadImage(query, axios_config);
   } else {
-    const _query = query.trim().split(/ +/).join('+');
+    const _query = encodeURIComponent(query);
 
     if (ris)
       throw new Utils.SearchError('Reverse image search by URL has been deprecated by Google. Please use a file instead.');
 
-    const url = encodeURI(
+    const url = 
       ris ?
         `${Constants.URLS.W_GOOGLE}searchbyimage?image_url=${_query}` :
-        `${Constants.URLS.GOOGLE}search?q=${_query}&ie=UTF-8&aomd=1${(safe ? '&safe=active' : '')}&start=${page}`
-    );
+        `${Constants.URLS.GOOGLE}search?q=${_query}&ie=UTF-8&aomd=1${(safe ? '&safe=active' : '')}&start=${page}`;
 
     response = await Axios.get(url, {
       params: additional_params,


### PR DESCRIPTION
Queries with special characters are not properly encoded. Instead, `encodeUriComponent()` should be used to encode the query string. There is no need to call `encodeUri()` on the Google search url because all parameters are already encoded.