### PR TITLE
Add SELECTORS override option, fix current TITLE selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ const options = {
   additional_params: { 
     // add additional parameters here, see https://moz.com/blog/the-ultimate-guide-to-the-google-search-parameters and https://www.seoquake.com/blog/google-search-param/
     hl: 'en' 
+  },
+  SELECTORS: {
+    // allow overriding cheerio selectors in case Google class names change. See constants.js for all selectors
+    TITLE: "div.q8U8x.oewGkc.LeUQr",
   }
 }
   

--- a/lib/core/main.js
+++ b/lib/core/main.js
@@ -45,6 +45,8 @@ async function search(query, options = {}) {
   const additional_params = options.additional_params || {};
   const axios_config = options.axios_config || {};
 
+  if (options.SELECTORS) Object.assign(Constants.SELECTORS, options.SELECTORS);
+
   if (typeof query === 'object' && ris) {
     response = await uploadImage(query, axios_config);
   } else {

--- a/lib/utils/constants.js
+++ b/lib/utils/constants.js
@@ -10,7 +10,7 @@ module.exports = {
   },
   SELECTORS: {
     // Organic Search Results 
-    TITLE: 'div.ynAwRc.q8U8x.MBeuO.gsrt.oewGkc.LeUQr',
+    TITLE: 'div.q8U8x.oewGkc.LeUQr',
     DESCRIPTION: 'div.MUxGbd.yDYNvb',
     URL: 'a.C8nzq.BmP5tf',
 


### PR DESCRIPTION
## Description

Adds the ability to override Constants.SELECTORS if passed in via search options. This should alleviate some of the urgency to update npm every time Google changes things. It does change Constants.SELECTORS permanently, but I can't think of a reason why you wouldn't want that.

Also fixes the current TITLE selector so all tests pass (from https://github.com/LuanRT/google-this/issues/66)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
